### PR TITLE
Adding option to disable virtual text

### DIFF
--- a/lua/corn.lua
+++ b/lua/corn.lua
@@ -12,6 +12,11 @@ M.setup = function(opts)
   -- setup renderer
   renderer.setup()
 
+  -- disable virtual text
+  if config.opts.disable_virtual_text then
+    vim.diagnostic.config({ virtual_text = false })
+  end
+
   -- setup auto_cmds
   if config.opts.auto_cmds then
     vim.api.nvim_create_autocmd({
@@ -34,6 +39,11 @@ end
 
 -- TODO: make a single Corn commands with autocompleted sub commands
 function M.toggle()
+  -- disable virtual text, but only if it was enabled
+  if config.opts.disable_virtual_text then
+    utils.toggle_virtual_text()
+  end
+
   renderer.toggle_hide()
 end
 vim.api.nvim_create_user_command("CornToggle", M.toggle, {})

--- a/lua/corn/config.lua
+++ b/lua/corn/config.lua
@@ -15,6 +15,7 @@ M.default_opts = {
     hint = "H",
     info = "I",
   },
+  disable_virtual_text = true,
 }
 
 M.opts = {}

--- a/lua/corn/utils.lua
+++ b/lua/corn/utils.lua
@@ -42,4 +42,8 @@ M.diag_severity_to_icon = function(severity)
   return look_up[severity] or '-'
 end
 
+M.toggle_virtual_text = function ()
+  vim.diagnostic.config({ virtual_text = not vim.diagnostic.config().virtual_text })
+end
+
 return M


### PR DESCRIPTION
As I understood, the plugin is there to keep LSP diagnostics at the corner to avoid inline cluttering. I, therefore, think that adding the functionality to disable virtual text with this plugin might be handy. 

I added the option `disable_virtual_text` to the configs such that virtual text is getting disabled and only shown in the corner. If the user toggles `corn` than the virtual text is enabled again. 

Depending on what you have in mind about the  toggling logic and the config defaults, aswell as the code, depends on you. So feel free to deny or change the PR as much as you want :) 