### PR TITLE
feature enhancement: render corn on mode change event

### DIFF
--- a/lua/corn.lua
+++ b/lua/corn.lua
@@ -24,6 +24,7 @@ M.setup = function(opts)
       "TextChanged",
       "TextChangedI",
       "WinResized",
+      "ModeChanged",
     }, {
       group = vim.api.nvim_create_augroup("corn", {}),
       callback = function()


### PR DESCRIPTION
Expressing gratitude for the recent addition of the `blacklisted_modes` feature. 
This PR suggests a minor change to enable toggling Corn when the mode changes spontaneously. Currently, it requires changing the mode and then moving the cursor to toggle off. In my setup, I used to achieve this before the feature (to reduce clutter when writing in insert mode, of course :) ) by relying on the ModeChanged event.

Thank you

