### PR TITLE
fix: disable undo on render buffer to avoid memory build-up

### DIFF
--- a/lua/corn/renderer.lua
+++ b/lua/corn/renderer.lua
@@ -57,9 +57,8 @@ end
 
 M.setup = function()
   M.bufnr = vim.api.nvim_create_buf(false, true)
-  -- Avoid an unecessary memory build-up because we're flushing the buffer 
-  -- every time, growing the undo log a lot at each new render.
-  vim.api.nvim_set_option_value("undolevels", -1, {  buf = M.bufnr })
+  vim.api.nvim_buf_set_option(M.bufnr, "undolevels", -1)
+
   M.ns = vim.api.nvim_create_namespace('corn')
 end
 

--- a/lua/corn/renderer.lua
+++ b/lua/corn/renderer.lua
@@ -57,6 +57,9 @@ end
 
 M.setup = function()
   M.bufnr = vim.api.nvim_create_buf(false, true)
+  -- Avoid an unecessary memory build-up because we're flushing the buffer 
+  -- every time, growing the undo log a lot at each new render.
+  vim.api.nvim_set_option_value("undolevels", -1, {  buf = M.bufnr })
   M.ns = vim.api.nvim_create_namespace('corn')
 end
 


### PR DESCRIPTION
My understanding is that since the render function writes the full buffer every time to write the new lines to render, the undo log is creating an entry containing basically a full file each time. The memory quickly grows because of that.

A way to test it is to open a buffer with an LSP attached to it, write some invalid syntax on many lines, and simply move the cursor many times on those lines. If you watch the nvim memory usage (`watch -d -n 1 "ps -ax -o pid,%mem,command | grep nvim | grep -v grep"`), you should see it increase.