### PR TITLE
Fix #13: Check win_is_valid before trying to win_hide

### DIFF
--- a/lua/corn/renderer.lua
+++ b/lua/corn/renderer.lua
@@ -183,7 +183,9 @@ M.render = function(items)
   -- either close_win, open_win or win_set_config
   if not M.should_render then
     if M.win then
-      vim.api.nvim_win_hide(M.win)
+      if vim.api.nvim_win_is_valid(M.win) then
+        vim.api.nvim_win_hide(M.win)
+      end
       M.win = nil
     end
   elseif not M.win then


### PR DESCRIPTION
I was able to reproduce #13 under a variety of circumstances, but most reliable was:

1. `:e file1.foo`
1. `:tabe file2.foo`
1. Navigate to diagnostic, so that the corn window renders
1. `:q`

Result:
```
Error detected while processing CursorMoved Autocommands for "*":
Error executing lua callback: ...y/.local/share/nvim/lazy/corn.nvim/lua/corn/renderer.lua:186: Invalid window id: 1046
stack traceback:
        [C]: in function 'nvim_win_hide'
        ...y/.local/share/nvim/lazy/corn.nvim/lua/corn/renderer.lua:186: in function 'render'
        ...s/plindsay/.local/share/nvim/lazy/corn.nvim/lua/corn.lua:124: in function 'render'
        ...s/plindsay/.local/share/nvim/lazy/corn.nvim/lua/corn.lua:32: in function <...s/plindsay/.local/share/nvim/lazy/corn.nvim/lua/corn.lua:31>
```

It seems as though the corn window is sometimes destroyed before the renderer can hide it. Wrapping the call to `nvim_win_hide` in a check for `nvim_win_is_valid` prevents this exception.
